### PR TITLE
Convert Cronitor item key

### DIFF
--- a/zabbix/zabbix_app_docker_template.xml
+++ b/zabbix/zabbix_app_docker_template.xml
@@ -428,7 +428,7 @@ sudo service zabbix-agent restart</description>
     </templates>
     <triggers>
         <trigger>
-            <expression>{Template App Docker - Jim Cronqvist:system.run[&quot;docker ps --filter 'status=running' | wc -l&quot;].last()}&lt;{Template App Docker - Jim Cronqvist:system.run[&quot;docker ps --filter 'status=running' | wc -l&quot;].max(3d)}</expression>
+            <expression>{Template App Docker - Jim Cronqvist:system.run[&quot;docker ps --filter 'status=running' | wc -l&quot;].last()}&lt;{Template App Docker - Jim Cronqvist:system.run[&quot;docker ps --filter 'status=running' | wc -l&quot;].last(,3d)}</expression>
             <recovery_mode>0</recovery_mode>
             <recovery_expression/>
             <name>The number of Docker containers running has decresed on {HOST.NAME}</name>

--- a/zabbix/zabbix_service_cronitor_template.xml
+++ b/zabbix/zabbix_service_cronitor_template.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <zabbix_export>
     <version>4.0</version>
-    <date>2019-01-26T15:51:17Z</date>
+    <date>2019-09-26T07:08:29Z</date>
     <groups>
         <group>
             <name>Templates</name>
@@ -29,7 +29,7 @@
                     <type>0</type>
                     <snmp_community/>
                     <snmp_oid/>
-                    <key>system.run[&quot;curl -s https://cronitor.io/v3/monitors?format=json -u '{$API_KEY}:'|grep -Po '{?\&quot;(code|name)\&quot;:\&quot;.*?\&quot;'|tr '\n ' '\054'|sed 's/\x2C{/}\x2C{/gi'|sed 's/.$/}/'|sed 's/\(name\|code\)/{#\U\1}/g'|awk '{print \&quot;{ data :[\&quot;$1\&quot;]}\&quot;}'|tr ' ' '\&quot;'&quot;]</key>
+                    <key>cronitor.discovery</key>
                     <delay>30m</delay>
                     <status>0</status>
                     <allowed_hosts/>
@@ -53,7 +53,7 @@
                         <formula/>
                         <conditions/>
                     </filter>
-                    <lifetime>30d</lifetime>
+                    <lifetime>3d</lifetime>
                     <description/>
                     <item_prototypes>
                         <item_prototype>
@@ -61,10 +61,10 @@
                             <type>0</type>
                             <snmp_community/>
                             <snmp_oid/>
-                            <key>system.run[&quot;curl -s https://cronitor.io/v3/monitors/{#CODE} -u '{$API_KEY}:' | grep '\&quot;passing\&quot;:true' | wc -l&quot;]</key>
+                            <key>system.run[&quot;curl -s https://cronitor.io/v3/monitors/{#CODE} -u '{$API_KEY}:' | grep -E '\&quot;passing\&quot;:true|\&quot;status\&quot;:\&quot;Healthy' | wc -l&quot;]</key>
                             <delay>60s</delay>
-                            <history>30d</history>
-                            <trends>365d</trends>
+                            <history>15d</history>
+                            <trends>30d</trends>
                             <status>0</status>
                             <value_type>3</value_type>
                             <allowed_hosts/>


### PR DESCRIPTION
- Previously using **system.run** to create valid Zabbix-style JSON. The change utilize UserParameter in itemkey instead.

- One more condition for Cronitor API checks. Specifically for **Portal HTTPS Heartbeat**.